### PR TITLE
🐛 Feature/#85 url double slash 오류 수정

### DIFF
--- a/crews/urls.py
+++ b/crews/urls.py
@@ -6,10 +6,10 @@ from . import views
 app_name = "crews"
 
 router = DefaultRouter()
+router.register(r"manage/(?P<crew_id>\d+)/members", views.CrewMemberViewSet, basename="joinedcrew")
+router.register(r"(?P<crew_id>\d+)/reviews", views.CrewReviewViewSet, basename="crewreview")
+router.register("manage", views.ManagerCrewViewSet, basename="manage_crew")
 router.register("", views.PublicCrewViewSet, basename="public_crew")
-router.register("manage/", views.ManagerCrewViewSet, basename="manage_crew")
-router.register("(?P<crew_id>\\d+)/reviews/", views.CrewReviewViewSet, basename="crewreview")
-router.register("manage/(?P<crew_id>\\d+)/members/", views.CrewMemberViewSet, basename="joinedcrew")
 
 urlpatterns = [
     path("", include(router.urls)),


### PR DESCRIPTION
- double slash를 고치면 test 오류가, test를 통과시키면 double slash 오류가 발생했음.
- url 선언 순서를 변경해줘서 해결.